### PR TITLE
[integration] CE-150: Migrate node-db-connector Staging Connections to MongoDB Atlas

### DIFF
--- a/example.js
+++ b/example.js
@@ -9,7 +9,7 @@ const db = require('./src/index.js')
 void async function(){
   try{
     await db.init([{
-      connectionString: 'mongodb://stg.mongodb.internal.swaven.com:29800/wtb',
+      connectionString: 'mongodb+srv://commerce-experience-stg-pl-0.n6iv5.mongodb.net/wtb',
       // secret: 'stg-mongo-awe-2'
     }])
     console.log('DB open')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-db-connector",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-db-connector",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.297.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-db-connector",
-  "version": "6.0.4",
+  "version": "6.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-db-connector",
-      "version": "6.0.4",
+      "version": "6.1.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.297.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-db-connector",
-  "version": "6.1.1",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-db-connector",
-      "version": "6.1.1",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.297.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-db-connector",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Unified db management",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-db-connector",
-  "version": "6.1.1",
+  "version": "6.1.0",
   "description": "Unified db management",
   "main": "src/index.js",
   "scripts": {

--- a/tests/mongo.js
+++ b/tests/mongo.js
@@ -58,7 +58,7 @@ const samples = [
   {
     test: 'Secret',
     cfg: {
-      connectionString: 'mongodb://username:password@stg.mongodb.internal.swaven.com:29800/authdb',
+      connectionString: 'mongodb+srv://username:password@commerce-experience-stg-pl-0.n6iv5.mongodb.net/authdb',
       secret: 'stg-mongo-awe-2',
       name: 'wtb'
     },
@@ -67,7 +67,7 @@ const samples = [
   {
     test: 'Secret no auth',
     cfg: {
-      connectionString: 'mongodb://stg.mongodb.internal.swaven.com:29800',
+      connectionString: 'mongodb+srv://commerce-experience-stg-pl-0.n6iv5.mongodb.net',
       secret: 'stg-mongo-awe-2',
       name: 'wtb'
     },


### PR DESCRIPTION
[CE-150](https://mikmakai.atlassian.net/browse/CE-150)

### This PR will...
...Update the connection strings for staging MongoDB to the ones for the new Atlas cluster, via the private endpoint connection

### Why is this Pull Request needed?
As a MikMak Developer, I want to migrate our MongoDB instances from the self-hosted community edition in EC2 to MongoDB Atlas, so I can take advantage of its monitoring, failover, and availability features.

### Are there any Pull Requests open in other repos which need to be merged with this?
No

### Screenshots (if appropriate)
N/A

### How/What to Test
Test connection string examples via the test tool.

### Todos (if any)
N/A

### Additional Comments/Concerns
N/A

#### Developer Checklist
- [X] I have written tests for any new or updated functionality
- [X] I have created/updated documentation if necessary
- [X] I have tested my code locally (or deployed for integration>main, main>integration)
- [X] I made sure that there are no other pull requests that solve for this issue
- [X] My code follows the same structure within the guidelines

[CE-150]: https://mikmakai.atlassian.net/browse/CE-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ