### PR TITLE
Fix mongo connection string parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-db-connector",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Unified db management",
   "main": "src/index.js",
   "scripts": {

--- a/src/connectionUri.js
+++ b/src/connectionUri.js
@@ -14,7 +14,7 @@ class ConnectionURI{
   static async parse(config){
     let uri
     try{
-      const rx = /^(?<schema>mongodb(\+srv)?|redis|mysql):\/\/(?:(?<user>.+):(?<pwd>.+)@)?(?<host>[^\/]+?)(?:\/(?<name>.+?))?(?:\?(?<opts>.+))?$/
+      const rx = /^(?<schema>mongodb(?:\+srv)?|redis|mysql):\/\/(?:(?<user>.+):(?<pwd>.+)@)?(?<host>[^\/]+?)(?:\/(?<name>.+?)?)?(?:\?(?<opts>.+))?$/
       const m = config.connectionString.match(rx)
       if (!m)
         throw new Error('Invalid connection string')


### PR DESCRIPTION
Regex did not support a connection string ending with '/' without a dbname.