### PR TITLE
ME-2394: Replace saslprep package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.297.0",
+        "@mongodb-js/saslprep": "^1.2.2",
         "mongodb": "^4.17.2",
         "promise-mysql": "^3.3.2",
         "promise-redis-legacy": "^1.0.0",
-        "saslprep": "^1.0.3",
         "verror": "^1.10.1"
       },
       "devDependencies": {
@@ -4324,7 +4324,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
       "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
-      "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -6182,17 +6181,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-db-connector",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "description": "Unified db management",
   "main": "src/index.js",
   "scripts": {
@@ -25,10 +25,10 @@
   "homepage": "https://github.com/Swaven/node-db-connector#readme",
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.297.0",
+    "@mongodb-js/saslprep": "^1.2.2",
     "mongodb": "^4.17.2",
     "promise-mysql": "^3.3.2",
     "promise-redis-legacy": "^1.0.0",
-    "saslprep": "^1.0.3",
     "verror": "^1.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove saslprep, use @mongodb-js/saslprep instead.

This package is noted as optional in mongo driver 4.x, becomes a real dependency in version 6.x