### PR TITLE
[master 2] ME-2455: Update MongoDB Driver in node-db-connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-db-connector",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-db-connector",
-      "version": "6.1.7",
+      "version": "6.1.8",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.297.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-db-connector",
-  "version": "6.1.7",
+  "version": "6.1.8",
   "description": "Unified db management",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 const VError = require('verror')
 const ConnectionURI = require('./connectionUri.js')
-const MongoDB = require('mongodb');
 
 class DbConnector {
   constructor(){
@@ -37,8 +36,9 @@ class DbConnector {
     // find & connect to mongo DBs
     var mongoConfigs = configs.filter((x) => {return x.connectionString.startsWith('mongodb')})
     if (mongoConfigs.length > 0){
+      const mongodb = require('mongodb');
       for (let cfg of mongoConfigs){
-        this._connectMongo(cfg)
+        this._connectMongo(mongodb, cfg)
       }
     }
 
@@ -108,7 +108,7 @@ class DbConnector {
   }
 
   // connecto to Mongo using native driver
-  _connectMongo(config){
+  _connectMongo(mongodb, config){
     this._connPromises.push(new Promise(async (resolve, reject) => {
       const uri = await ConnectionURI.parse(config)
       
@@ -116,7 +116,7 @@ class DbConnector {
         return reject('No DB name in connection string or config')
       
       const clientName = (config.name || uri.authdb).toString() // name of the mongo client for the connection
-      const mongoclient = new MongoDB.MongoClient(uri.toString())
+      const mongoclient = new mongodb.MongoClient(uri.toString())
       mongoclient.connect()
         .then((client) => {
           // names of database to reference


### PR DESCRIPTION
[ME-2455](https://mikmakai.atlassian.net/browse/ME-2455)

At some point, it looks like the MongoDB driver changed the connection management APIs and removed the `connect()` method overload used here.

I'm not really clear on how this has been working... I found [here](https://mongodb.github.io/node-mongodb-native/4.17/classes/MongoClient.html#connect) the documentation for the [previous version we were using](https://github.com/Swaven/node-db-connector/pull/40/files), but it doesn't mention an overload including the URI and options parameters; it only mentions the callback parameter.

I found it in the [documentation for version 3.6](https://mongodb.github.io/node-mongodb-native/3.6/api/lib_mongo_client.js.html) (the last major version we used before 4, and [where this code was adopted](https://github.com/Swaven/node-db-connector/commit/8a66175e1943087302d8acbebfe1cf8bc6487a56)), but since it was (seemingly?) removed with v4, I don't get how our connections were succeeding.

In any case, the [callback API was entirely removed (in favor of promises) with v5](https://github.com/mongodb/node-mongodb-native/blob/main/etc/notes/CHANGES_5.0.0.md#optional-callback-support-migrated-to-mongodb-legacy), so we have to change it now.

[ME-2455]: https://mikmakai.atlassian.net/browse/ME-2455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ