### PR TITLE
ME-7176: Remove obsolete dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Unified db connection mgmt: provides a simple way to connect to MongoDB, Mysql a
 It uses the following drivers:  
 Mongo: [Mongoose](http://mongoosejs.com/) or [native driver](http://mongodb.github.io/node-mongodb-native/4.17.2/)  
 Mysql: [promise-mysql](https://github.com/lukeb-uk/node-promise-mysql)  
-Redis: [promise-redis-legacy](https://github.com/swaven/promise-redis-legacy)  
+Redis: [redis](https://github.com/redis/node-redis)  
 **PostgreSQL support was removed in version 3.0.0 as we do not use it anymore.**
 
 This package only handles connection & disconnect. Please refer to each driver's own documentation for how to query the DBs.
@@ -27,6 +27,10 @@ This package only handles connection & disconnect. Please refer to each driver's
       console.error('Something horrible happened: ' + err)
     }
 ````
+
+## Breaking changes
+
+⚠️ **node-db-connector@v7** does not comes with its own redis driver anymore. It's up to dependant packages to install it if they use a redis connection.
 
 ## API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,15 @@
         "@mongodb-js/saslprep": "1.4.6",
         "mongodb": "6.21.0",
         "promise-mysql": "3.3.2",
-        "promise-redis-legacy": "1.0.1",
         "verror": "1.10.1"
       },
       "devDependencies": {
         "chai": "^4.5.0",
         "chai-as-promised": "^7.1.2",
         "mocha": "^11.7.5"
+      },
+      "peerDependencies": {
+        "redis": "^4.7.1"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -1648,15 +1650,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/diff": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -2268,16 +2261,6 @@
         "mysql": "^2.17.1"
       }
     },
-    "node_modules/promise-redis-legacy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-redis-legacy/-/promise-redis-legacy-1.0.1.tgz",
-      "integrity": "sha512-H2u8PpueW09NTxhxP83QDb/L2e1cXLwQ1HaxvODb9zHTk5cl8irdI3XvhLhVz6p9dMVtdkBJTH1GJzcn9vmSOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "redis": "^3.1.2",
-        "redis-commands": "^1.7.0"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2324,52 +2307,6 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/redis": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
-      "license": "MIT",
-      "dependencies": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-redis"
-      }
-    },
-    "node_modules/redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-      "license": "MIT"
-    },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "license": "MIT",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "@mongodb-js/saslprep": "1.4.6",
     "mongodb": "6.21.0",
     "promise-mysql": "3.3.2",
-    "promise-redis-legacy": "1.0.1",
     "verror": "1.10.1"
+  },
+  "peerDependencies": {
+    "redis": ">=4.7.1"
   },
   "devDependencies": {
     "chai": "^4.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ class DbConnector {
     // find redis configs
     var redisConfigs = configs.filter((x) => {return x.connectionString.startsWith('redis://')})
     if (redisConfigs.length > 0){
-      let redis = require('promise-redis-legacy')()
+      let redis = require('redis')
 
       for (let cfg of redisConfigs){
         this._connectRedis(cfg, redis)


### PR DESCRIPTION
Remove promise-redis-legacy: obsolete package, locked down to obsolete redis driver.
Use node-redis as peer dependency: must be installed by dependent of node-db-connector. Version constraint is lax for maximum compatibility with any dependent package that may already use the common redis package.

**TODO: version bump to 7.0.0 before publishing to npm.**